### PR TITLE
Fixed an issue affecting PHP 7.2 and missing fonts

### DIFF
--- a/src/views/main/_field.php
+++ b/src/views/main/_field.php
@@ -13,7 +13,7 @@
 
 $field->getFontCss();
 
-if (count($icons) > 0) {
+if (is_array($icons) && count($icons) > 0) {
     ?>
 
 


### PR DESCRIPTION
Resolves an issue where an error exception is thrown when fonts are missing or removed from the resources-shared folder, after adding data to an entry.

<img width="870" alt="screen shot 2019-02-10 at 7 59 32 pm" src="https://user-images.githubusercontent.com/5515179/52530741-6bd0a880-2d6e-11e9-81e3-954a4ee8acd9.png">
